### PR TITLE
Avoid using deprecated Buffer API

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,12 @@
 var stream = require('readable-stream')
 var inherits = require('inherits')
 
-var SIGNAL_FLUSH = new Buffer([0])
+var SIGNAL_FLUSH
+if (Buffer.from && Buffer.from !== Uint8Array.from) {
+  SIGNAL_FLUSH = Buffer.from([0])
+} else {
+  SIGNAL_FLUSH = new Buffer([0])
+}
 
 module.exports = WriteStream
 


### PR DESCRIPTION
Use Buffer.from when it's available instead of 'new Bufer(arr)'

Refs:
https://nodejs.org/api/deprecations.html#deprecations_dep0005_buffer_constructor

This is one of the three changes needed to keep `npm i` working under `NODE_PENDING_DEPRECATION=1` without warnings. The other two are https://github.com/mafintosh/duplexify/pull/17 and https://github.com/npm/node-tar/pull/175.